### PR TITLE
Exclude property also excludes directories

### DIFF
--- a/context/watcher.go
+++ b/context/watcher.go
@@ -25,7 +25,7 @@ func (w *Watcher) Launch(ctx *Context, jobsC chan<- Job) {
 	w.Targets = make(map[string]map[string]os.FileInfo)
 	watchDir := ctx.Wd
 	if w.Directory != "" {
-		watchDir = watchDir+"/"+w.Directory
+		watchDir = watchDir + "/" + w.Directory
 	}
 	w.readDir(watchDir, true)
 	w.Printf("%s", "Watching...")
@@ -37,6 +37,9 @@ func (w *Watcher) Launch(ctx *Context, jobsC chan<- Job) {
 
 // readDir reads the directory named by dirname.
 func (w *Watcher) readDir(dirname string, init bool) error {
+	if w.excludeDir(dirname) {
+		return nil
+	}
 	fileInfos, err := ioutil.ReadDir(dirname)
 	if err != nil {
 		return err
@@ -112,6 +115,17 @@ func (w *Watcher) Printf(format string, v ...interface{}) {
 func (w *Watcher) exclude(filename string) bool {
 	for _, excludeFilename := range w.Excludes {
 		if filename == excludeFilename {
+			return true
+		}
+	}
+	return false
+}
+
+// excludeDir returns true if the dir should be not watched.
+func (w *Watcher) excludeDir(dirname string) bool {
+	for _, excludeFilename := range w.Excludes {
+		excludeFilename = strings.TrimRight(excludeFilename, "*/")
+		if strings.Contains(dirname, excludeFilename) {
 			return true
 		}
 	}

--- a/context/watcher_test.go
+++ b/context/watcher_test.go
@@ -1,1 +1,41 @@
 package context
+
+import "testing"
+
+func TestExcludeDir(t *testing.T) {
+	testData := []struct {
+		excludes []string
+		dirname  string
+		exclude  bool
+	}{
+		{
+			excludes: []string{"a/", "b/*"},
+			dirname:  "/n/p/a",
+			exclude:  true,
+		},
+		{
+			excludes: []string{"a/", "b/*"},
+			dirname:  "/n/p/b",
+			exclude:  true,
+		},
+		{
+			excludes: []string{"a/", "b/*"},
+			dirname:  "/n/p/c",
+			exclude:  false,
+		},
+		{
+			excludes: []string{"a/", "../../b/*"},
+			dirname:  "/n/p/../../b",
+			exclude:  true,
+		},
+	}
+	for i, td := range testData {
+		w := Watcher{
+			Excludes: td.excludes,
+		}
+		exclude := w.excludeDir(td.dirname)
+		if td.exclude != exclude {
+			t.Fatalf("[%d] exp: %t got: %t", i, td.exclude, exclude)
+		}
+	}
+}


### PR DESCRIPTION
Ability to exclude directories from the watched path.

It works by specifying path which is matched as string and it will ignore this directory and all subdirectories underneath.

Linked to previous issue.
#17 